### PR TITLE
Fix average_neighbor_degree calculations for directed graph

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -23,6 +23,25 @@ X contributors. Highlights include:
 Improvements
 ------------
 
+- Correction to the treatment of directed graphs for `average_neighbor_degree`
+  which used to sum the degrees of outgoing neighbors only but then divide by
+  the number of "in" or "out" or "in+out" neighbors. So it wasn't even an average.
+  The correction makes it an average degree of whatever population of neighbors
+  is specified by `source` = "in" or "out" or "in+out".
+  For example:
+
+      >>> G = nx.path_graph(3, create_using=nx.DiGraph)
+      >>> print(nx.average_neighbor_degree(G, source="in", target="in"))
+      {0: 0.0, 1: 1.0, 2: 1.0}
+
+  This used to produce `{0: 0.0, 1: 1.0, 2: 0.0}`
+  Note: node 0 and 2 were treated nonsensically.
+  Node 0 had calculated value 1/0 which was converted to 0.
+  (numerator looking at successors while denominator counting predecessors)
+  Node 2 had caluated value 0/1 = 0.0 (again succs on top, but preds in bottom)
+
+  Now node 0 has calculated value 0.0/0 which we treat as 0.0. And node 2 has
+  calculated value 1/1 = 1.0. Both handle the same nbrhood on top and bottom.
 
 API Changes
 -----------

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -139,7 +139,7 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
     # based on the arguments passed to the method we will populate them or leave them empty
     G_P = G_S = {n: {} for n in G}
 
-    # if G is a directed graph,
+    # if G is a directed graph
     if G.is_directed():
         # if source includes 'in' ("in" or "in+out" cases), G_P will be populated with predecessors
         if "in" in source:

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -4,12 +4,12 @@ __all__ = ["average_neighbor_degree"]
 
 
 def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=None):
-    r"""Returns the average degree of the neighborhood of each node. 
-    
-    In an undirected graph, the neighborhood of a node is the list of nodes which are connected to the given node with an edge.   
+    r"""Returns the average degree of the neighborhood of each node.
+
+    In an undirected graph, the neighborhood of a node is the list of nodes which are connected to the given node with an edge.
 
     In a directed graph, the neighborhood of a node will depend on the argument passed to source parameter when calling the function:
-    
+
         - if source is 'in', then the neighborhood of the node is the list of nodes which are predecessors of the given node,
         - if source is 'out', then the neighborhood of the node is the list of nodes which are successors of the given node,
         - if source is 'in+out', then the neighborhood of the node is the list of nodes which are either predecessors or successors of the given node.
@@ -134,28 +134,28 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
     # average degree of neighbors
     avg = {}
     # edges in the graph together with their weights
-    edges = G.edges(data=True)    
-    
+    edges = G.edges(data=True)
+
     for n, deg in source_degree(nodes, weight=weight):
         # normalize but not by zero degree
         if deg == 0:
             avg[n] = 0.0
             continue
-        
+
         # if G is an undirected graph, G_n is neighbors of n
-        G_n = G[n]     
+        G_n = G[n]
 
         """
         if G is a directed graph, 
             if source is 'in', G_n will be predecessors of n
             else if source is 'out', G_n will be successors of n
-        """        
-        if G.is_directed():            
+        """
+        if G.is_directed():
             G_n = {}
             if source == "in":
                 for start, end, weight_dict in edges:
                     if end == n:
-                        G_n[start] = weight_dict                    
+                        G_n[start] = weight_dict
             elif source == "out":
                 for start, end, weight_dict in edges:
                     if start == n:

--- a/networkx/algorithms/assortativity/neighbor_degree.py
+++ b/networkx/algorithms/assortativity/neighbor_degree.py
@@ -4,7 +4,15 @@ __all__ = ["average_neighbor_degree"]
 
 
 def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=None):
-    r"""Returns the average degree of the neighborhood of each node.
+    r"""Returns the average degree of the neighborhood of each node. 
+    
+    In an undirected graph, the neighborhood of a node is the list of nodes which are connected to the given node with an edge.   
+
+    In a directed graph, the neighborhood of a node will depend on the argument passed to source parameter when calling the function:
+    
+        - if source is 'in', then the neighborhood of the node is the list of nodes which are predecessors of the given node,
+        - if source is 'out', then the neighborhood of the node is the list of nodes which are successors of the given node,
+        - if source is 'in+out', then the neighborhood of the node is the list of nodes which are either predecessors or successors of the given node.
 
     The average neighborhood degree of a node `i` is
 
@@ -71,7 +79,7 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
     >>> G = nx.DiGraph()
     >>> nx.add_path(G, [0, 1, 2, 3])
     >>> nx.average_neighbor_degree(G, source="in", target="in")
-    {0: 0.0, 1: 1.0, 2: 1.0, 3: 0.0}
+    {0: 0.0, 1: 0.0, 2: 1.0, 3: 1.0}
 
     >>> nx.average_neighbor_degree(G, source="out", target="out")
     {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0}
@@ -125,12 +133,34 @@ def average_neighbor_degree(G, source="out", target="out", nodes=None, weight=No
     tgt_deg = dict(target_degree())
     # average degree of neighbors
     avg = {}
+    # edges in the graph together with their weights
+    edges = G.edges(data=True)    
+    
     for n, deg in source_degree(nodes, weight=weight):
         # normalize but not by zero degree
         if deg == 0:
             avg[n] = 0.0
             continue
-        G_n = G[n]
+        
+        # if G is an undirected graph, G_n is neighbors of n
+        G_n = G[n]     
+
+        """
+        if G is a directed graph, 
+            if source is 'in', G_n will be predecessors of n
+            else if source is 'out', G_n will be successors of n
+        """        
+        if G.is_directed():            
+            G_n = {}
+            if source == "in":
+                for start, end, weight_dict in edges:
+                    if end == n:
+                        G_n[start] = weight_dict                    
+            elif source == "out":
+                for start, end, weight_dict in edges:
+                    if start == n:
+                        G_n[end] = weight_dict
+
         if weight is None:
             avg[n] = sum(tgt_deg[nbr] for nbr in G_n) / deg
         else:

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest 
 
 import networkx as nx
 
@@ -18,11 +18,12 @@ class TestAverageNeighbor:
         nd = nx.average_neighbor_degree(D)
         assert nd == {0: 1, 1: 1, 2: 0, 3: 0}
         nd = nx.average_neighbor_degree(D, "in", "out")
-        assert nd == {0: 0, 1: 1, 2: 0, 3: 0}
+        assert nd == {0: 0, 1: 1, 2: 1, 3: 1}                     
         nd = nx.average_neighbor_degree(D, "out", "in")
         assert nd == {0: 1, 1: 1, 2: 1, 3: 0}
         nd = nx.average_neighbor_degree(D, "in", "in")
-        assert nd == {0: 0, 1: 1, 2: 1, 3: 0}
+        assert nd == {0: 0, 1: 0, 2: 1, 3: 1}
+                     
 
     def test_degree_p4_weighted(self):
         G = nx.path_graph(4)
@@ -42,9 +43,9 @@ class TestAverageNeighbor:
         nd = nx.average_neighbor_degree(D, "out", "out", weight="weight")
         assert nd == {0: 1, 1: 1, 2: 0, 3: 0}
         nd = nx.average_neighbor_degree(D, "in", "in", weight="weight")
-        assert nd == {0: 0, 1: 4, 2: 0.25, 3: 0}
+        assert nd == {0: 0, 1: 0, 2: 1, 3: 1}
         nd = nx.average_neighbor_degree(D, "in", "out", weight="weight")
-        assert nd == {0: 0, 1: 4, 2: 0, 3: 0}
+        assert nd == {0: 0, 1: 1, 2: 1, 3: 1}
         nd = nx.average_neighbor_degree(D, "out", "in", weight="weight")
         assert nd == {0: 1, 1: 1, 2: 1, 3: 0}
 

--- a/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
+++ b/networkx/algorithms/assortativity/tests/test_neighbor_degree.py
@@ -1,4 +1,4 @@
-import pytest 
+import pytest
 
 import networkx as nx
 
@@ -18,12 +18,11 @@ class TestAverageNeighbor:
         nd = nx.average_neighbor_degree(D)
         assert nd == {0: 1, 1: 1, 2: 0, 3: 0}
         nd = nx.average_neighbor_degree(D, "in", "out")
-        assert nd == {0: 0, 1: 1, 2: 1, 3: 1}                     
+        assert nd == {0: 0, 1: 1, 2: 1, 3: 1}
         nd = nx.average_neighbor_degree(D, "out", "in")
         assert nd == {0: 1, 1: 1, 2: 1, 3: 0}
         nd = nx.average_neighbor_degree(D, "in", "in")
         assert nd == {0: 0, 1: 0, 2: 1, 3: 1}
-                     
 
     def test_degree_p4_weighted(self):
         G = nx.path_graph(4)


### PR DESCRIPTION
Issue Number: 5383

The neighbors of a node should be decided based on the source argument passed to the function. If source argument is "in", then the neighbors are nodes which have an edge "to" the given node. If source argument is "out", then the neighbors are nodes which have an edge "from" the given node.  

For example:
     Graph G = 1 -> 2 -> 3 -> 4
     for node 2,
           if source == "in" then, the neighbors are:  node 1
           else if source == "out" then, the neighbors are: node 3.

I also ran all tests and updated some assert statements in the test file (test_neighbor_degree.py). I used pen and paper to check the work. 
